### PR TITLE
ci(trunk): refresh caller workflow

### DIFF
--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -1,23 +1,30 @@
 ---
-name: "⭕ Trunk"
+name: Trunk Code Quality
+
 on:
   push:
     branches: [main]
     tags: ["v*.*.*"]
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   schedule:
     - cron: "0 05 * * 5"
-  workflow_dispatch:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:
-    if: github.event.schedule != '0 05 * * 5'
-    name: "⚡"
+    name: Trunk Code Quality
+    permissions:
+      actions: read
+      checks: write
+      contents: read
     uses: z-shell/.github/.github/workflows/trunk.yml@main
-  upload:
-    if: github.event.schedule == '0 05 * * 5'
-    name: "🆙"
-    uses: z-shell/.github/.github/workflows/trunk.yml@main
-    secrets:
-      trunk-token: ${{ secrets.TRUNK_TOKEN }}
+    with:
+      arguments: --no-progress


### PR DESCRIPTION
Refresh the Trunk caller workflow to the standardized org shape (Batch A: deprecated token wiring), per z-shell/.github#408.

## Changes
- Remove the deprecated scheduled `upload` job and its `trunk-token: ${{ secrets.TRUNK_TOKEN }}` wiring (Trunk Code Quality web-app uploads are retired).
- Plain-text workflow name `Trunk Code Quality` (drops emoji name).
- Add top-level `permissions: contents: read` and explicit job permissions (`actions: read`, `checks: write`).
- Add `concurrency` to cancel stale push/PR runs.
- Pass `arguments: --no-progress` for readable logs.
- Preserve the existing weekly schedule (`0 05 * * 5`); the single `check` job now also covers scheduled runs.

Matches the established rollout shape (e.g. z-shell/zbrowse#43, z-shell/H-S-MW#4).

Refs z-shell/.github#408